### PR TITLE
Rename `delta` to `eps` for float-based assertions

### DIFF
--- a/lib/galaxy/tool_util/verify/asserts/image.py
+++ b/lib/galaxy/tool_util/verify/asserts/image.py
@@ -156,7 +156,7 @@ def assert_has_image_mean_intensity(
     output_bytes: bytes,
     channel: Optional[Union[int, str]] = None,
     value: Optional[Union[float, str]] = None,
-    delta: Union[float, str] = 0.01,
+    eps: Union[float, str] = 0.01,
     min: Optional[Union[float, str]] = None,
     max: Optional[Union[float, str]] = None,
 ) -> None:
@@ -167,7 +167,7 @@ def assert_has_image_mean_intensity(
     _assert_float(
         actual=im_arr.mean(),
         label="mean intensity",
-        tolerance=delta,
+        tolerance=eps,
         expected=value,
         range_min=min,
         range_max=max,
@@ -178,7 +178,7 @@ def assert_has_image_center_of_mass(
     output_bytes: bytes,
     channel: Optional[Union[int, str]] = None,
     point: Optional[Union[Tuple[float, float], str]] = None,
-    delta: Union[float, str] = 0.01,
+    eps: Union[float, str] = 0.01,
 ) -> None:
     """
     Asserts the specified output is an image and has the specified center of mass.
@@ -193,8 +193,8 @@ def assert_has_image_center_of_mass(
         actual_center_of_mass = _compute_center_of_mass(im_arr)
         distance = numpy.linalg.norm(numpy.subtract(point, actual_center_of_mass))
         assert distance <= float(
-            delta
-        ), f"Wrong center of mass: {actual_center_of_mass} (expected {point}, distance: {distance}, delta: {delta})"
+            eps
+        ), f"Wrong center of mass: {actual_center_of_mass} (expected {point}, distance: {distance}, eps: {eps})"
 
 
 def _get_image_labels(
@@ -271,7 +271,7 @@ def assert_has_image_mean_object_size(
     labels: Optional[Union[str, List[int]]] = None,
     exclude_labels: Optional[Union[str, List[int]]] = None,
     value: Optional[Union[float, str]] = None,
-    delta: Union[float, str] = 0.01,
+    eps: Union[float, str] = 0.01,
     min: Optional[Union[float, str]] = None,
     max: Optional[Union[float, str]] = None,
 ) -> None:
@@ -283,7 +283,7 @@ def assert_has_image_mean_object_size(
     _assert_float(
         actual=actual_mean_object_size,
         label="mean object size",
-        tolerance=delta,
+        tolerance=eps,
         expected=value,
         range_min=min,
         range_max=max,

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2858,7 +2858,7 @@ $attribute_list::5
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
 Asserts the output is an image and has a specific mean intensity value of ``value``
-plus/minus ``delta`` (e.g., ``<image_has_mean_intensity value="0.83" />``).
+plus/minus ``eps`` (e.g., ``<image_has_mean_intensity value="0.83" />``).
 Alternatively the range of the expected mean intensity value can be specified by ``min`` and/or ``max``.
 
 $attribute_list::5
@@ -2870,9 +2870,9 @@ $attribute_list::5
         <xs:documentation xml:lang="en">The required mean value of the image intensities.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="delta" type="xs:float" use="optional" default="0.01">
+    <xs:attribute name="eps" type="xs:float" use="optional" default="0.01">
       <xs:annotation>
-        <xs:documentation xml:lang="en">The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean value of the image intensities has to be in the range ``value +- delta``.</xs:documentation>
+        <xs:documentation xml:lang="en">The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean value of the image intensities has to be in the range ``value +- eps``.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="min" type="xs:float" use="optional">
@@ -2895,7 +2895,7 @@ $attribute_list::5
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
 Asserts the output is an image and has a specific center of mass of ``point``,
-or has an Euclidean distance of ``delta`` or less to that point (e.g.,
+or has an Euclidean distance of ``eps`` or less to that point (e.g.,
 ``<has_image_center_of_mass point="511.07, 223.34" />``).
 
 $attribute_list::5
@@ -2907,7 +2907,7 @@ $attribute_list::5
         <xs:documentation xml:lang="en">The required center of mass of the image intensities (horizontal and vertical coordinate, separated by a comma).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="delta" type="xs:float" use="optional" default="0.01">
+    <xs:attribute name="eps" type="xs:float" use="optional" default="0.01">
       <xs:annotation>
         <xs:documentation xml:lang="en">The maximum allowed Euclidean distance to the required center of mass (defaults to ``0.01``).</xs:documentation>
       </xs:annotation>
@@ -2969,8 +2969,9 @@ $attribute_list::5
   <xs:complexType name="AssertHasImageMeanObjectSize">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
-Asserts the output is an image with labeled objects which have the specified mean size (number of pixels, e.g.,
-``<has_image_mean_object_size value="111.87" exclude_labels="0" />``). The labels must be unique.
+Asserts the output is an image with labeled objects which have the specified mean size (number of pixels),
+plus/minus ``eps`` (e.g., ``<has_image_mean_object_size value="111.87" exclude_labels="0" />``).
+The labels must be unique.
 
 $attribute_list::5
 ]]>
@@ -2981,9 +2982,9 @@ $attribute_list::5
         <xs:documentation xml:lang="en">The required mean size of the uniquely labeled objects.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="delta" type="xs:float" use="optional" default="0.01">
+    <xs:attribute name="eps" type="xs:float" use="optional" default="0.01">
       <xs:annotation>
-        <xs:documentation xml:lang="en">The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean size of the uniquely labeled objects has to be in the range ``value +- delta``.</xs:documentation>
+        <xs:documentation xml:lang="en">The absolute tolerance to be used for ``value`` (defaults to ``0.01``). The observed mean size of the uniquely labeled objects has to be in the range ``value +- eps``.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="min" type="xs:float" use="optional">

--- a/test/functional/tools/validation_image.xml
+++ b/test/functional/tools/validation_image.xml
@@ -49,7 +49,23 @@
             <param name="input" value="im3_b.tif" />
             <output name="output">
                 <assert_contents>
-                    <has_image_mean_intensity channel="0" value="0.24" delta="0.0100000001" />
+                    <has_image_mean_intensity channel="0" value="0.24" eps="0.0100000001" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="input" value="im3_b.tif" />
+            <output name="output">
+                <assert_contents>
+                    <has_image_mean_intensity channel="0" value="0.23" delta="2" />
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_test_failure="true">
+            <param name="input" value="im3_b.tif" />
+            <output name="output">
+                <assert_contents>
+                    <has_image_mean_intensity channel="0" value="0.22" delta="2" />
                 </assert_contents>
             </output>
         </test>
@@ -122,7 +138,7 @@
             <param name="input" value="im2_b.png" />
             <output name="output">
                 <assert_contents>
-                    <has_image_mean_object_size value="511" delta="0.9" />
+                    <has_image_mean_object_size value="511" eps="0.9" />
                 </assert_contents>
             </output>
         </test>
@@ -134,7 +150,7 @@
                     <has_image_height value="32" />
                     <has_image_channels value="1" />
                     <has_image_labels value="2" />
-                    <has_image_mean_object_size value="511" delta="1.0" />
+                    <has_image_mean_object_size value="511" eps="1.0" />
                 </assert_contents>
             </output>
         </test>

--- a/test/functional/tools/validation_image.xml
+++ b/test/functional/tools/validation_image.xml
@@ -25,6 +25,22 @@
             <param name="input" value="im3_b.tif" />
             <output name="output">
                 <assert_contents>
+                    <has_image_width value="30" delta="2" />
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_test_failure="true">
+            <param name="input" value="im3_b.tif" />
+            <output name="output">
+                <assert_contents>
+                    <has_image_width value="29" delta="2" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="input" value="im3_b.tif" />
+            <output name="output">
+                <assert_contents>
                     <has_image_width value="32" />
                     <has_image_height value="32" />
                     <has_image_channels value="3" />
@@ -50,22 +66,6 @@
             <output name="output">
                 <assert_contents>
                     <has_image_mean_intensity channel="0" value="0.24" eps="0.0100000001" />
-                </assert_contents>
-            </output>
-        </test>
-        <test>
-            <param name="input" value="im3_b.tif" />
-            <output name="output">
-                <assert_contents>
-                    <has_image_mean_intensity channel="0" value="0.23" delta="2" />
-                </assert_contents>
-            </output>
-        </test>
-        <test expect_test_failure="true">
-            <param name="input" value="im3_b.tif" />
-            <output name="output">
-                <assert_contents>
-                    <has_image_mean_intensity channel="0" value="0.22" delta="2" />
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
Optional addition for https://github.com/galaxyproject/galaxy/pull/17581

Rename `delta` to `eps` for float-based assertions:
 - `<has_image_mean_intensity>`
 - `<has_image_center_of_mass>`
 - `<assert_has_image_mean_object_size>`