### PR TITLE
Suppress mypy error

### DIFF
--- a/test/unit/data/datatypes/test_images.py
+++ b/test/unit/data/datatypes/test_images.py
@@ -1,5 +1,6 @@
 from galaxy.datatypes.images import (
     Image,
+    Pdf,
     Tiff,
 )
 from .util import (
@@ -127,3 +128,10 @@ test_png_channels_0 = __create_test(Image, "im1_uint8.png", "channels", 0)
 test_png_channels_3 = __create_test(Image, "im3_a.png", "channels", 3)
 test_png_depth_0 = __create_test(Image, "im1_uint8.png", "depth", 0)
 test_png_frames_1 = __create_test(Image, "im1_uint8.png", "frames", 1)
+
+
+# Test with files that neither Pillow nor tifffile can open
+
+@__test(Pdf, "454Score.pdf")
+def test_unsupported_metadata(metadata):
+    __assert_empty_metadata(metadata)

--- a/test/unit/data/datatypes/test_images.py
+++ b/test/unit/data/datatypes/test_images.py
@@ -24,7 +24,7 @@ def __test(image_cls: Type[Image], input_filename: str):
         def test():
             image = image_cls()
             with get_input_files(input_filename) as input_files:
-                dataset: DatasetProtocol = MockDataset(1)  # type: ignore
+                dataset: DatasetProtocol = MockDataset(1)  # type: ignore[assignment]
                 dataset.set_file_name(input_files[0])
                 image.set_meta(dataset)
                 test_impl(dataset.metadata)

--- a/test/unit/data/datatypes/test_images.py
+++ b/test/unit/data/datatypes/test_images.py
@@ -1,16 +1,21 @@
+from typing import (
+    Any,
+    Type,
+)
+
 from galaxy.datatypes.images import (
     Image,
     Pdf,
     Tiff,
 )
+from galaxy.datatypes.protocols import DatasetProtocol
 from .util import (
     get_input_files,
     MockDataset,
 )
-from typing import Any, Type
-
 
 # Define test decorator
+
 
 def __test(image_cls: Type[Image], input_filename: str):
 
@@ -19,7 +24,7 @@ def __test(image_cls: Type[Image], input_filename: str):
         def test():
             image = image_cls()
             with get_input_files(input_filename) as input_files:
-                dataset = MockDataset(1)
+                dataset: DatasetProtocol = MockDataset(1)
                 dataset.set_file_name(input_files[0])
                 image.set_meta(dataset)
                 test_impl(dataset.metadata)
@@ -31,6 +36,7 @@ def __test(image_cls: Type[Image], input_filename: str):
 
 # Define test factory
 
+
 def __create_test(image_cls: Type[Image], input_filename: str, metadata_key: str, expected_value: Any):
 
     @__test(image_cls, input_filename)
@@ -41,6 +47,7 @@ def __create_test(image_cls: Type[Image], input_filename: str, metadata_key: str
 
 
 # Define test utilities
+
 
 def __assert_empty_metadata(metadata):
     for key in (
@@ -131,6 +138,7 @@ test_png_frames_1 = __create_test(Image, "im1_uint8.png", "frames", 1)
 
 
 # Test with files that neither Pillow nor tifffile can open
+
 
 @__test(Pdf, "454Score.pdf")
 def test_unsupported_metadata(metadata):

--- a/test/unit/data/datatypes/test_images.py
+++ b/test/unit/data/datatypes/test_images.py
@@ -24,9 +24,9 @@ def __test(image_cls: Type[Image], input_filename: str):
         def test():
             image = image_cls()
             with get_input_files(input_filename) as input_files:
-                dataset: DatasetProtocol = MockDataset(1)  # type: ignore[assignment]
+                dataset = MockDataset(1)
                 dataset.set_file_name(input_files[0])
-                image.set_meta(dataset)
+                image.set_meta(dataset)  # type: ignore[arg-type]
                 test_impl(dataset.metadata)
 
         return test

--- a/test/unit/data/datatypes/test_images.py
+++ b/test/unit/data/datatypes/test_images.py
@@ -24,7 +24,7 @@ def __test(image_cls: Type[Image], input_filename: str):
         def test():
             image = image_cls()
             with get_input_files(input_filename) as input_files:
-                dataset: DatasetProtocol = MockDataset(1)
+                dataset: DatasetProtocol = MockDataset(1)  # type: ignore
                 dataset.set_file_name(input_files[0])
                 image.set_meta(dataset)
                 test_impl(dataset.metadata)

--- a/test/unit/data/datatypes/test_images.py
+++ b/test/unit/data/datatypes/test_images.py
@@ -8,7 +8,6 @@ from galaxy.datatypes.images import (
     Pdf,
     Tiff,
 )
-from galaxy.datatypes.protocols import DatasetProtocol
 from .util import (
     get_input_files,
     MockDataset,


### PR DESCRIPTION
Suppress the error

> test/unit/data/datatypes/test_images.py:23: error: Argument 1 to "set_meta" of "Image" has incompatible type "MockDataset"; expected "DatasetProtocol"

by inline annotation:

```python
image.set_meta(dataset)  # type: ignore[arg-type]
```